### PR TITLE
Add task for installing PPA for MySQL 5.6.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,9 @@
+# edX is currently using MySQL 5.6, which is not available on Xenial by default.
+- name: Add PPA for MySQL 5.6
+  apt_repository:
+    repo: "ppa:ondrej/mysql-5.6"
+    update_cache: yes
+
 - name: Create mysql group
   group: name=mysql system=yes
 
@@ -33,4 +39,3 @@
     owner: root
     group: root
     mode: "500"
-


### PR DESCRIPTION
This makes it possible to install MySQL 5.6 on Xenial hosts.

Part of the scope of [OC-2277](https://tasks.opencraft.com/browse/OC-2277).

**Reviewers**

- [x] @smarnach 