### PR TITLE
Remove fstab entry for /var/lib/mysql since we are now using zfs

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,9 +10,6 @@
 - name: Create mysql user
   user: name=mysql group=mysql system=yes
 
-- name: mount /var/lib/mysql
-  mount: name=/var/lib/mysql src="{{MYSQL_OPENSTACK_DB_DEVICE}}" fstype=ext4 state=mounted
-
 - name: chown -R /var/lib/mysql
   file: path=/var/lib/mysql owner=mysql group=mysql recurse=yes state=directory
 


### PR DESCRIPTION
This removes the ansible mount options which add an entry to `/etc/fstab` for the MySQL data directory in `/var/lib/mysql`.

Since we are now switching to ZFS, we don't need to add this entry, and it could cause failure at boot, since the zfs volume will not be able to be mounted as ext4.